### PR TITLE
Fix deprecated GitHub Actions

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         
@@ -50,7 +50,7 @@ jobs:
         python enhanced_monitor.py --mode single
         
     - name: Upload logs and state
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: monitoring-logs


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4
- Update actions/setup-python from v4 to v5
- Resolve workflow failure due to deprecated actions

🤖 Generated with [Claude Code](https://claude.ai/code)